### PR TITLE
LookupSPByACSWithIssuerFallback

### DIFF
--- a/identity_provider.go
+++ b/identity_provider.go
@@ -367,31 +367,13 @@ type IdpAuthnRequest struct {
 	LookupSPByACSWithFallback bool
 }
 
-type IdpAuthnRequestOption func(*idpAuthnRequestOptions)
-
-type idpAuthnRequestOptions struct {
-	lookupSPByACSWithFallback bool
-}
-
-func WithLookupSPByACSWithFallback() IdpAuthnRequestOption {
-	return func(o *idpAuthnRequestOptions) {
-		o.lookupSPByACSWithFallback = true
-	}
-}
-
 // NewIdpAuthnRequest returns a new IdpAuthnRequest for the given HTTP request to the authorization
 // service.
-func NewIdpAuthnRequest(idp *IdentityProvider, r *http.Request, opts ...IdpAuthnRequestOption) (*IdpAuthnRequest, error) {
-	o := idpAuthnRequestOptions{}
-	for _, opt := range opts {
-		opt(&o)
-	}
-
+func NewIdpAuthnRequest(idp *IdentityProvider, r *http.Request) (*IdpAuthnRequest, error) {
 	req := &IdpAuthnRequest{
-		IDP:                       idp,
-		HTTPRequest:               r,
-		Now:                       TimeNow(),
-		LookupSPByACSWithFallback: o.lookupSPByACSWithFallback,
+		IDP:         idp,
+		HTTPRequest: r,
+		Now:         TimeNow(),
 	}
 
 	switch r.Method {

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -60,6 +60,18 @@ type SessionProvider interface {
 	GetSession(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session
 }
 
+type GetSPOptions struct {
+	ACSURL string
+}
+
+type GetSPOpt func(*GetSPOptions)
+
+func WithACSURL(acsURL string) GetSPOpt {
+	return func(o *GetSPOptions) {
+		o.ACSURL = acsURL
+	}
+}
+
 // ServiceProviderProvider is an interface used by IdentityProvider to look up
 // service provider metadata for a request.
 type ServiceProviderProvider interface {
@@ -67,7 +79,7 @@ type ServiceProviderProvider interface {
 	// service provider ID, which is typically the service provider's
 	// metadata URL. If an appropriate service provider cannot be found then
 	// the returned error must be os.ErrNotExist.
-	GetServiceProvider(r *http.Request, serviceProviderID string) (*EntityDescriptor, error)
+	GetServiceProvider(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error)
 }
 
 // AssertionMaker is an interface used by IdentityProvider to construct the
@@ -339,28 +351,40 @@ func (idp *IdentityProvider) ServeIDPInitiated(w http.ResponseWriter, r *http.Re
 
 // IdpAuthnRequest is used by IdentityProvider to handle a single authentication request.
 type IdpAuthnRequest struct {
-	IDP                     *IdentityProvider
-	HTTPRequest             *http.Request
-	RelayState              string
-	RequestBuffer           []byte
-	Request                 AuthnRequest
-	ServiceProviderMetadata *EntityDescriptor
-	SPSSODescriptor         *SPSSODescriptor
-	ACSEndpoint             *IndexedEndpoint
-	Assertion               *Assertion
-	AssertionEl             *etree.Element
-	ResponseEl              *etree.Element
-	Now                     time.Time
-	IDPInitiated            bool
+	IDP                       *IdentityProvider
+	HTTPRequest               *http.Request
+	RelayState                string
+	RequestBuffer             []byte
+	Request                   AuthnRequest
+	ServiceProviderMetadata   *EntityDescriptor
+	SPSSODescriptor           *SPSSODescriptor
+	ACSEndpoint               *IndexedEndpoint
+	Assertion                 *Assertion
+	AssertionEl               *etree.Element
+	ResponseEl                *etree.Element
+	Now                       time.Time
+	IDPInitiated              bool
+	LookupSPByACSWithFallback bool
+}
+
+// WithLookupSPByACSWithFallback is an option helper that sets the LookupSPByACS flag
+func WithLookupSPByACSWithFallback(enabled bool) func(*IdpAuthnRequest) {
+	return func(req *IdpAuthnRequest) {
+		req.LookupSPByACSWithFallback = enabled
+	}
 }
 
 // NewIdpAuthnRequest returns a new IdpAuthnRequest for the given HTTP request to the authorization
 // service.
-func NewIdpAuthnRequest(idp *IdentityProvider, r *http.Request) (*IdpAuthnRequest, error) {
+func NewIdpAuthnRequest(idp *IdentityProvider, r *http.Request, opts ...func(*IdpAuthnRequest)) (*IdpAuthnRequest, error) {
 	req := &IdpAuthnRequest{
 		IDP:         idp,
 		HTTPRequest: r,
 		Now:         TimeNow(),
+	}
+
+	for _, opt := range opts {
+		opt(req)
 	}
 
 	switch r.Method {
@@ -514,9 +538,15 @@ func (req *IdpAuthnRequest) Validate() error {
 		return ErrInvalidSAMLRequest.WithMessagef("Expected SAML request version 2.0 got %v", req.Request.Version)
 	}
 
+	var opts []GetSPOpt
+
+	if req.LookupSPByACSWithFallback {
+		opts = append(opts, WithACSURL(req.Request.AssertionConsumerServiceURL))
+	}
+
 	// find the service provider
 	serviceProviderID := req.Request.Issuer.Value
-	serviceProvider, err := req.IDP.ServiceProviderProvider.GetServiceProvider(req.HTTPRequest, serviceProviderID)
+	serviceProvider, err := req.IDP.ServiceProviderProvider.GetServiceProvider(req.HTTPRequest, serviceProviderID, opts...)
 	if err != nil {
 		return ErrUnknownServiceProvider.WithErrorf(err, "cannot handle request from unknown service provider %s", serviceProviderID)
 	}

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -367,24 +367,31 @@ type IdpAuthnRequest struct {
 	LookupSPByACSWithFallback bool
 }
 
-// WithLookupSPByACSWithFallback is an option helper that sets the LookupSPByACS flag
-func WithLookupSPByACSWithFallback(enabled bool) func(*IdpAuthnRequest) {
-	return func(req *IdpAuthnRequest) {
-		req.LookupSPByACSWithFallback = enabled
+type IdpAuthnRequestOption func(*idpAuthnRequestOptions)
+
+type idpAuthnRequestOptions struct {
+	lookupSPByACSWithFallback bool
+}
+
+func WithLookupSPByACSWithFallback() IdpAuthnRequestOption {
+	return func(o *idpAuthnRequestOptions) {
+		o.lookupSPByACSWithFallback = true
 	}
 }
 
 // NewIdpAuthnRequest returns a new IdpAuthnRequest for the given HTTP request to the authorization
 // service.
-func NewIdpAuthnRequest(idp *IdentityProvider, r *http.Request, opts ...func(*IdpAuthnRequest)) (*IdpAuthnRequest, error) {
-	req := &IdpAuthnRequest{
-		IDP:         idp,
-		HTTPRequest: r,
-		Now:         TimeNow(),
+func NewIdpAuthnRequest(idp *IdentityProvider, r *http.Request, opts ...IdpAuthnRequestOption) (*IdpAuthnRequest, error) {
+	o := idpAuthnRequestOptions{}
+	for _, opt := range opts {
+		opt(&o)
 	}
 
-	for _, opt := range opts {
-		opt(req)
+	req := &IdpAuthnRequest{
+		IDP:                       idp,
+		HTTPRequest:               r,
+		Now:                       TimeNow(),
+		LookupSPByACSWithFallback: o.lookupSPByACSWithFallback,
 	}
 
 	switch r.Method {

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -102,7 +102,7 @@ func NewIdentifyProviderTest(t *testing.T) *IdentityProviderTest {
 		MetadataURL: "https://idp.example.com/saml/metadata",
 		SSOURL:      mustParseURL("https://idp.example.com/saml/sso"),
 		ServiceProviderProvider: &mockServiceProviderProvider{
-			GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+			GetServiceProviderFunc: func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
 				if serviceProviderID == test.SP.MetadataURL.String() {
 					return test.SP.Metadata(), nil
 				}
@@ -130,11 +130,11 @@ func (msp *mockSessionProvider) GetSession(w http.ResponseWriter, r *http.Reques
 }
 
 type mockServiceProviderProvider struct {
-	GetServiceProviderFunc func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error)
+	GetServiceProviderFunc func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error)
 }
 
-func (mspp *mockServiceProviderProvider) GetServiceProvider(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
-	return mspp.GetServiceProviderFunc(r, serviceProviderID)
+func (mspp *mockServiceProviderProvider) GetServiceProvider(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
+	return mspp.GetServiceProviderFunc(r, serviceProviderID, opts...)
 }
 
 func TestIDPCanProduceMetadata(t *testing.T) {
@@ -810,7 +810,7 @@ func TestIDPCanHandleUnencryptedResponse(t *testing.T) {
 		&metadata)
 	assert.Check(t, err)
 	test.IDP.ServiceProviderProvider = &mockServiceProviderProvider{
-		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
 			if serviceProviderID == "https://gitlab.example.com/users/saml/metadata" {
 				return &metadata, nil
 			}
@@ -986,7 +986,7 @@ func TestIDPNoDestination(t *testing.T) {
 	err := xml.Unmarshal(golden.Get(t, "TestIDPNoDestination_idp_metadata.xml"), &metadata)
 	assert.Check(t, err)
 	test.IDP.ServiceProviderProvider = &mockServiceProviderProvider{
-		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
 			if serviceProviderID == "https://gitlab.example.com/users/saml/metadata" {
 				return &metadata, nil
 			}

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -102,7 +102,7 @@ func NewIdentifyProviderTest(t *testing.T) *IdentityProviderTest {
 		MetadataURL: "https://idp.example.com/saml/metadata",
 		SSOURL:      mustParseURL("https://idp.example.com/saml/sso"),
 		ServiceProviderProvider: &mockServiceProviderProvider{
-			GetServiceProviderFunc: func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
+			GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
 				if serviceProviderID == test.SP.MetadataURL.String() {
 					return test.SP.Metadata(), nil
 				}
@@ -130,11 +130,11 @@ func (msp *mockSessionProvider) GetSession(w http.ResponseWriter, r *http.Reques
 }
 
 type mockServiceProviderProvider struct {
-	GetServiceProviderFunc func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error)
+	GetServiceProviderFunc func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error)
 }
 
-func (mspp *mockServiceProviderProvider) GetServiceProvider(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
-	return mspp.GetServiceProviderFunc(r, serviceProviderID, opts...)
+func (mspp *mockServiceProviderProvider) GetServiceProvider(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+	return mspp.GetServiceProviderFunc(r, serviceProviderID)
 }
 
 func TestIDPCanProduceMetadata(t *testing.T) {
@@ -810,7 +810,7 @@ func TestIDPCanHandleUnencryptedResponse(t *testing.T) {
 		&metadata)
 	assert.Check(t, err)
 	test.IDP.ServiceProviderProvider = &mockServiceProviderProvider{
-		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
+		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
 			if serviceProviderID == "https://gitlab.example.com/users/saml/metadata" {
 				return &metadata, nil
 			}
@@ -986,7 +986,7 @@ func TestIDPNoDestination(t *testing.T) {
 	err := xml.Unmarshal(golden.Get(t, "TestIDPNoDestination_idp_metadata.xml"), &metadata)
 	assert.Check(t, err)
 	test.IDP.ServiceProviderProvider = &mockServiceProviderProvider{
-		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string, opts ...GetSPOpt) (*EntityDescriptor, error) {
+		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
 			if serviceProviderID == "https://gitlab.example.com/users/saml/metadata" {
 				return &metadata, nil
 			}

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -25,7 +25,7 @@ type Service struct {
 // service provider ID, which is typically the service provider's
 // metadata URL. If an appropriate service provider cannot be found then
 // the returned error must be os.ErrNotExist.
-func (s *Server) GetServiceProvider(_ *http.Request, serviceProviderID string) (*saml.EntityDescriptor, error) {
+func (s *Server) GetServiceProvider(_ *http.Request, serviceProviderID string, opts ...saml.GetSPOpt) (*saml.EntityDescriptor, error) {
 	s.idpConfigMu.RLock()
 	defer s.idpConfigMu.RUnlock()
 	rv, ok := s.serviceProviders[serviceProviderID]

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -25,7 +25,7 @@ type Service struct {
 // service provider ID, which is typically the service provider's
 // metadata URL. If an appropriate service provider cannot be found then
 // the returned error must be os.ErrNotExist.
-func (s *Server) GetServiceProvider(_ *http.Request, serviceProviderID string, opts ...saml.GetSPOpt) (*saml.EntityDescriptor, error) {
+func (s *Server) GetServiceProvider(_ *http.Request, serviceProviderID string) (*saml.EntityDescriptor, error) {
 	s.idpConfigMu.RLock()
 	defer s.idpConfigMu.RUnlock()
 	rv, ok := s.serviceProviders[serviceProviderID]


### PR DESCRIPTION
Add a new flag LookupSPByACSWithIssuerFallback to lookup SP by ACS URL from the SAML Request with Issuer fallback.
Refactor GetSPIssuer to get the entire AuthnRequest.